### PR TITLE
Refactor: Display only one message in chat UI

### DIFF
--- a/wearable-app/app/src/androidTest/java/com/example/wearableaichat/MainActivityUITest.kt
+++ b/wearable-app/app/src/androidTest/java/com/example/wearableaichat/MainActivityUITest.kt
@@ -1,0 +1,220 @@
+package com.example.wearableaichat
+
+import android.app.Activity
+import android.app.Instrumentation
+import android.content.Intent
+import android.speech.RecognizerIntent
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.matcher.IntentMatchers
+import androidx.test.espresso.intent.rule.IntentsTestRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.wearableaichat.network.ApiService
+import com.example.wearableaichat.network.ChatRequest
+import com.example.wearableaichat.network.ChatResponse
+import com.example.wearableaichat.network.RetrofitClient
+import kotlinx.coroutines.runBlocking
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import retrofit2.Response
+
+@RunWith(AndroidJUnit4::class)
+class MainActivityUITest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    @get:Rule
+    val intentsTestRule = IntentsTestRule(MainActivity::class.java)
+
+    private lateinit var mockApiService: MockApiService
+    private lateinit var originalApiService: ApiService
+
+
+    // String resources - it's better to load them via composeTestRule.activity.getString(R.string.X)
+    // but for simplicity in this context, we'll hardcode them and ensure they match strings.xml
+    private val stringAiPrefix by lazy { composeTestRule.activity.getString(R.string.ai_prefix) }
+    private val stringUserPrefix by lazy { composeTestRule.activity.getString(R.string.user_prefix) }
+    private val initialPrompt by lazy { composeTestRule.activity.getString(R.string.message_initial_prompt) }
+    private val thinkingMessage by lazy { stringAiPrefix + composeTestRule.activity.getString(R.string.info_thinking) }
+    private val errorNetworkGeneric by lazy { stringAiPrefix + composeTestRule.activity.getString(R.string.error_network_generic) }
+    private val errorServerUnreachable by lazy { stringAiPrefix + composeTestRule.activity.getString(R.string.error_server_unreachable) }
+    private val errorAsrFailedCancelled by lazy { stringAiPrefix + composeTestRule.activity.getString(R.string.error_asr_failed_cancelled) }
+
+
+    inner class MockApiService : ApiService {
+        var simulateSuccess: Boolean = true
+        var responseMessage: String = "Test AI Response"
+        var errorCode: Int = 500
+        var simulateNetworkError: Boolean = false
+
+        override suspend fun sendMessage(request: ChatRequest): Response<ChatResponse> {
+            return if (simulateNetworkError) {
+                throw java.net.UnknownHostException("Simulated network error")
+            } else if (simulateSuccess) {
+                Response.success(ChatResponse(responseMessage, null))
+            } else {
+                Response.error(
+                    errorCode,
+                    "{\"error\":\"Simulated server error\"}".toResponseBody("application/json".toMediaTypeOrNull())
+                )
+            }
+        }
+    }
+
+    @Before
+    fun setUp() {
+        mockApiService = MockApiService()
+        // Get the original ApiService instance from RetrofitClient
+        originalApiService = RetrofitClient.instance
+
+        // Replace the original ApiService with the mock
+        RetrofitClient.instance = mockApiService
+
+        // Initialize string resources here using composeTestRule.activity
+        // This ensures that they are loaded after the activity is created.
+        // Example: initialPrompt = composeTestRule.activity.getString(R.string.message_initial_prompt)
+        // (already done with by lazy, but if not lazy, this is where it would go)
+    }
+
+
+    @Test
+    fun testInitialPromptIsDisplayed() {
+        composeTestRule.onNodeWithText(initialPrompt).assertIsDisplayed()
+    }
+
+    @Test
+    fun testUserMessageReplacesInitialPrompt() {
+        val userMessage = "Hello AI"
+        val fullUserMessage = stringUserPrefix + userMessage
+
+        // Mock successful speech recognition
+        val resultData = Intent()
+        resultData.putStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS, arrayListOf(userMessage))
+        Intents.intending(IntentMatchers.actionMatches(RecognizerIntent.ACTION_RECOGNIZE_SPEECH))
+            .respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, resultData))
+
+        composeTestRule.onNodeWithContentDescription(composeTestRule.activity.getString(R.string.cd_voice_input_button)).performClick()
+
+        composeTestRule.onNodeWithText(fullUserMessage).assertIsDisplayed()
+        composeTestRule.onNodeWithText(initialPrompt).assertDoesNotExist()
+    }
+
+    @Test
+    fun testThinkingMessageReplacesUserMessage() {
+        val userMessage = "Tell me a joke"
+        val fullUserMessage = stringUserPrefix + userMessage
+
+        val resultData = Intent()
+        resultData.putStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS, arrayListOf(userMessage))
+        Intents.intending(IntentMatchers.actionMatches(RecognizerIntent.ACTION_RECOGNIZE_SPEECH))
+            .respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, resultData))
+
+        composeTestRule.onNodeWithContentDescription(composeTestRule.activity.getString(R.string.cd_voice_input_button)).performClick()
+
+        // Verify user message is shown first
+        composeTestRule.onNodeWithText(fullUserMessage).assertIsDisplayed()
+
+        // Then, verify "Thinking..." message replaces it
+        composeTestRule.waitUntil(timeoutMillis = 2000) { // Give some time for the coroutine to launch
+            composeTestRule.onAllNodesWithText(thinkingMessage).fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText(thinkingMessage).assertIsDisplayed()
+        composeTestRule.onNodeWithText(fullUserMessage).assertDoesNotExist()
+        composeTestRule.onNodeWithText(initialPrompt).assertDoesNotExist()
+    }
+
+    @Test
+    fun testAIResponseMessageReplacesThinkingMessage() {
+        val userMessage = "What's the weather?"
+        val aiResponse = "It's sunny!"
+        val fullAiResponse = stringAiPrefix + aiResponse
+        mockApiService.responseMessage = aiResponse
+        mockApiService.simulateSuccess = true
+
+        val resultData = Intent()
+        resultData.putStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS, arrayListOf(userMessage))
+        Intents.intending(IntentMatchers.actionMatches(RecognizerIntent.ACTION_RECOGNIZE_SPEECH))
+            .respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, resultData))
+
+        composeTestRule.onNodeWithContentDescription(composeTestRule.activity.getString(R.string.cd_voice_input_button)).performClick()
+
+        // Wait for AI response
+        composeTestRule.waitUntil(timeoutMillis = 5000) { // Increased timeout for network op
+             composeTestRule.onAllNodesWithText(fullAiResponse).fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText(fullAiResponse).assertIsDisplayed()
+        composeTestRule.onNodeWithText(thinkingMessage).assertDoesNotExist()
+        composeTestRule.onNodeWithText(stringUserPrefix + userMessage).assertDoesNotExist()
+        composeTestRule.onNodeWithText(initialPrompt).assertDoesNotExist()
+    }
+
+    @Test
+    fun testNetworkErrorMessageReplacesThinkingMessage() {
+        val userMessage = "Test network error"
+        // The actual error message will be "AI: Server is unreachable" or "AI: Network error occurred (Simulated network error)"
+        // depending on the exact exception and string resource.
+        // Let's use a flexible check with startsWith for the prefix.
+        val expectedErrorMessagePrefix = errorServerUnreachable // More specific for UnknownHostException
+
+        mockApiService.simulateNetworkError = true
+
+        val resultData = Intent()
+        resultData.putStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS, arrayListOf(userMessage))
+        Intents.intending(IntentMatchers.actionMatches(RecognizerIntent.ACTION_RECOGNIZE_SPEECH))
+            .respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, resultData))
+
+        composeTestRule.onNodeWithContentDescription(composeTestRule.activity.getString(R.string.cd_voice_input_button)).performClick()
+
+        // Wait for error message
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            composeTestRule.onAllNodesWithText(expectedErrorMessagePrefix, substring = true).fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText(expectedErrorMessagePrefix, substring = true).assertIsDisplayed()
+        composeTestRule.onNodeWithText(thinkingMessage).assertDoesNotExist()
+        composeTestRule.onNodeWithText(stringUserPrefix + userMessage).assertDoesNotExist()
+        composeTestRule.onNodeWithText(initialPrompt).assertDoesNotExist()
+    }
+    
+    @Test
+    fun testServerErrorMessageReplacesThinkingMessage() {
+        val userMessage = "Test server error"
+        val
+                httpErrorPrefix = composeTestRule.activity.getString(R.string.error_server_http_error_prefix)
+        val expectedErrorMessage = stringAiPrefix + httpErrorPrefix + "500 Simulated server error" // Adjusted to match actual error construction
+
+        mockApiService.simulateSuccess = false
+        mockApiService.errorCode = 500
+
+
+        val resultData = Intent()
+        resultData.putStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS, arrayListOf(userMessage))
+        Intents.intending(IntentMatchers.actionMatches(RecognizerIntent.ACTION_RECOGNIZE_SPEECH))
+            .respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, resultData))
+
+        composeTestRule.onNodeWithContentDescription(composeTestRule.activity.getString(R.string.cd_voice_input_button)).performClick()
+
+        // Wait for error message
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            composeTestRule.onAllNodesWithText(expectedErrorMessage, substring = true).fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText(expectedErrorMessage, substring = true).assertIsDisplayed()
+        composeTestRule.onNodeWithText(thinkingMessage).assertDoesNotExist()
+        composeTestRule.onNodeWithText(stringUserPrefix + userMessage).assertDoesNotExist()
+        composeTestRule.onNodeWithText(initialPrompt).assertDoesNotExist()
+    }
+
+
+    @After
+    fun tearDown() {
+        // Restore the original ApiService instance
+        RetrofitClient.instance = originalApiService
+        Intents.release() // Release intents if initialized
+    }
+}

--- a/wearable-app/app/src/main/java/com/example/wearableaichat/MainActivity.kt
+++ b/wearable-app/app/src/main/java/com/example/wearableaichat/MainActivity.kt
@@ -30,7 +30,17 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.wear.compose.material.*
+import androidx.wear.compose.material.Button
+import androidx.wear.compose.material.Colors
+import androidx.wear.compose.material.Icon
+import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.Scaffold
+import androidx.wear.compose.material.Shapes
+import androidx.wear.compose.material.TextToSpeech
+import androidx.wear.compose.material.TimeText
+import androidx.wear.compose.material.Typography
+import androidx.wear.compose.material.Vignette
+import androidx.wear.compose.material.VignettePosition
 import com.example.wearableaichat.network.ChatRequest
 import com.example.wearableaichat.network.RetrofitClient
 import kotlinx.coroutines.launch
@@ -57,15 +67,12 @@ fun WearApp(
     apiService: com.example.wearableaichat.network.ApiService,
 ) {
     WearableAiChatTheme {
-        val listState = rememberScalingLazyListState()
         Scaffold(
-            timeText = { TimeText(modifier = Modifier.scrollAway(listState)) },
-            vignette = { Vignette(vignettePosition = VignettePosition.TopAndBottom) },
-            positionIndicator = { PositionIndicator(scalingLazyListState = listState) }
+            timeText = { TimeText() },
+            vignette = { Vignette(vignettePosition = VignettePosition.TopAndBottom) }
         ) {
             ChatScreen(
-                apiService = apiService,
-                listState = listState
+                apiService = apiService
             )
         }
     }
@@ -73,11 +80,10 @@ fun WearApp(
 
 @Composable
 fun ChatScreen(
-    apiService: com.example.wearableaichat.network.ApiService,
-    listState: ScalingLazyListState
+    apiService: com.example.wearableaichat.network.ApiService
 ) {
-    // Holds the list of messages displayed in the chat.
-    val messages = remember { mutableStateListOf<String>() }
+    // Holds the latest message displayed in the chat.
+    var messages by remember { mutableStateOf<String?>(null) }
     // Tracks if a network request is currently active (e.g., waiting for backend response).
     // Used to disable the microphone button to prevent concurrent requests.
     var isNetworkRequestInProgress by remember { mutableStateOf(false) }
@@ -105,14 +111,14 @@ fun ChatScreen(
             // Check if the language is available and supported.
             if (result == TextToSpeech.LANG_MISSING_DATA || result == TextToSpeech.LANG_NOT_SUPPORTED) {
                 Log.w("TTS", "TTS Language not supported.")
-                messages.add(stringAiPrefix + errorTtsLangNotSupported)
+                messages = stringAiPrefix + errorTtsLangNotSupported
             } else {
                 ttsInitialized = true // TTS is ready to use.
                 Log.d("TTS", "TTS Initialization successful.")
             }
         } else {
             Log.e("TTS", "TTS Initialization failed.")
-            messages.add(stringAiPrefix + errorTtsInitFailed)
+            messages = stringAiPrefix + errorTtsInitFailed
         }
     }
 
@@ -145,13 +151,6 @@ fun ChatScreen(
         }
     }
 
-    // Effect to automatically scroll to the newest message when the messages list changes.
-    LaunchedEffect(messages.size) {
-        if (messages.isNotEmpty()) {
-            listState.animateScrollToItem(messages.size - 1)
-        }
-    }
-
     val infoThinkingStrRes = stringResource(id = R.string.info_thinking)
     val errorAsrUnavailableStrRes = stringResource(id = R.string.error_asr_unavailable)
     val errorAsrNotRecognizedStrRes = stringResource(id = R.string.error_asr_not_recognized)
@@ -175,18 +174,18 @@ fun ChatScreen(
             Log.d("ChatScreen", "Speech recognition results: $results")
             if (!results.isNullOrEmpty()) {
                 val recognizedText = results[0]
-                messages.add(stringUserPrefix + recognizedText) // Add user's message to chat.
+                messages = stringUserPrefix + recognizedText // Add user's message to chat.
 
                 // Show "Thinking..." message and initiate network request.
                 val thinkingMessage = stringAiPrefix + infoThinkingStrRes
-                messages.add(thinkingMessage)
+                messages = thinkingMessage
                 isNetworkRequestInProgress = true // Disable mic button.
 
                 // Launch a coroutine to handle the network request.
                 coroutineScope.launch { // Changed to use coroutineScope
                     try {
                         val response = apiService.sendMessage(ChatRequest(recognizedText))
-                        messages.remove(thinkingMessage) // Remove "Thinking..." message.
+                        // messages.remove(thinkingMessage) // Remove "Thinking..." message. // Not needed anymore
 
                         if (response.isSuccessful) {
                             val chatResponse = response.body()
@@ -194,31 +193,31 @@ fun ChatScreen(
                                 if (chatResponse.response != null) {
                                     // AI successfully responded.
                                     val aiResponseText = stringAiPrefix + chatResponse.response
-                                    messages.add(aiResponseText)
+                                    messages = aiResponseText
                                     speak(aiResponseText) // Speak the AI's response.
                                 } else if (chatResponse.error != null) {
                                     // Backend returned an error (e.g., "No message provided").
-                                    messages.add(stringAiPrefix + errorServerHttpErrorPrefixStrRes + chatResponse.error)
+                                    messages = stringAiPrefix + errorServerHttpErrorPrefixStrRes + chatResponse.error
                                 } else {
                                     // Backend response was successful but empty/malformed.
-                                    messages.add(stringAiPrefix + errorServerEmptyResponseStrRes)
+                                    messages = stringAiPrefix + errorServerEmptyResponseStrRes
                                 }
                             } else {
                                 // Response body was null, indicating a malformed response from server.
-                                messages.add(stringAiPrefix + errorServerMalformedResponseStrRes)
+                                messages = stringAiPrefix + errorServerMalformedResponseStrRes
                             }
                         } else {
                             // HTTP error (e.g., 404, 500).
-                            messages.add(stringAiPrefix + errorServerHttpErrorPrefixStrRes + "${response.code()} ${response.message()}")
+                            messages = stringAiPrefix + errorServerHttpErrorPrefixStrRes + "${response.code()} ${response.message()}"
                         }
                     } catch (e: Exception) {
                         // Handle network exceptions (e.g., no internet, server unreachable).
-                        messages.remove(thinkingMessage) // Ensure "Thinking..." is removed on error.
+                        // messages.remove(thinkingMessage) // Ensure "Thinking..." is removed on error. // Not needed anymore
                         val errorMessage = when (e) {
                             is UnknownHostException, is ConnectException -> stringAiPrefix + errorServerUnreachableStrRes
                             else -> stringAiPrefix + errorNetworkGenericStrRes + " (${e.message})"
                         }
-                        messages.add(errorMessage)
+                        messages = errorMessage
                         Log.e("ChatScreen", "Network request failed", e)
                     } finally {
                         isNetworkRequestInProgress = false // Re-enable mic button.
@@ -226,17 +225,17 @@ fun ChatScreen(
                 }
             } else {
                 // Speech recognized, but no results (should be rare).
-                messages.add(stringAiPrefix + errorAsrNotRecognizedStrRes)
+                messages = stringAiPrefix + errorAsrNotRecognizedStrRes
             }
         } else {
             // Speech recognition failed or was cancelled by the user.
-            messages.add(stringAiPrefix + errorAsrFailedCancelledStrRes)
+            messages = stringAiPrefix + errorAsrFailedCancelledStrRes
         }
     }
 
     Box(modifier = Modifier.fillMaxSize()) {
         // Display initial prompt if no messages are present.
-        if (messages.isEmpty()) {
+        if (messages == null) {
             Text(
                 text = stringResource(id = R.string.message_initial_prompt),
                 modifier = Modifier
@@ -249,32 +248,21 @@ fun ChatScreen(
                 )
             )
         } else {
-            // Display the conversation history.
-            ScalingLazyColumn(
-                modifier = Modifier.fillMaxSize(),
-                state = listState,
-                contentPadding = PaddingValues(
-                    top = 20.dp,
-                    bottom = 70.dp,
-                    start = 8.dp,
-                    end = 8.dp
-                ), // Increased bottom padding
-                horizontalAlignment = Alignment.CenterHorizontally
+            // Display the current message.
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(bottom = 70.dp), // Ensure content is above the button
+                contentAlignment = Alignment.Center
             ) {
-                items(messages.size) { index ->
-                    MarkdownTelText(
-                        markdownText = messages[index],
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(vertical = 4.dp), // Padding for each message`
-                    )
-//                    androidx.wear.compose.material.Text(
-//                        text = messages[index],
-//                        modifier = Modifier
-//                            .fillMaxWidth()
-//                            .padding(vertical = 4.dp)
-//                    )
-                }
+                MarkdownTelText(
+                    markdownText = messages ?: "",
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp), // Padding for the message
+                    // Ensure text is centered if it's short, or starts from top if long
+                    // This is handled by Box contentAlignment and MarkdownTelText's own alignment
+                )
             }
         }
 
@@ -299,7 +287,7 @@ fun ChatScreen(
                     try {
                         speechRecognizerLauncher.launch(intent)
                     } catch (e: Exception) {
-                        messages.add(stringAiPrefix + errorAsrUnavailableStrRes)
+                            messages = stringAiPrefix + errorAsrUnavailableStrRes
                         Log.e("ChatScreen", "Speech recognition not available", e)
                     }
                 },
@@ -434,15 +422,12 @@ fun DefaultPreview() {
     }
 
     WearableAiChatTheme {
-        val listState = rememberScalingLazyListState()
         Scaffold(
-            timeText = { TimeText(modifier = Modifier.scrollAway(listState)) },
-            vignette = { Vignette(vignettePosition = VignettePosition.TopAndBottom) },
-            positionIndicator = { PositionIndicator(scalingLazyListState = listState) }
+            timeText = { TimeText() },
+            vignette = { Vignette(vignettePosition = VignettePosition.TopAndBottom) }
         ) {
             ChatScreen(
-                apiService = mockApiService,
-                listState = listState
+                apiService = mockApiService
             )
         }
     }

--- a/wearable-app/app/src/main/java/com/example/wearableaichat/MainActivity.kt
+++ b/wearable-app/app/src/main/java/com/example/wearableaichat/MainActivity.kt
@@ -36,7 +36,6 @@ import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Scaffold
 import androidx.wear.compose.material.Shapes
-import androidx.wear.compose.material.TextToSpeech
 import androidx.wear.compose.material.TimeText
 import androidx.wear.compose.material.Typography
 import androidx.wear.compose.material.Vignette
@@ -252,7 +251,7 @@ fun ChatScreen(
             Box(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(bottom = 70.dp), // Ensure content is above the button
+                    .padding(bottom = 50.dp), // Ensure content is above the button
                 contentAlignment = Alignment.Center
             ) {
                 MarkdownTelText(


### PR DESCRIPTION
According to a UX design change, the chat interface on the wearable app has been updated to display only a single message at a time (either from you or me, including intermediate states like "Thinking..." or error messages).

Changes include:
- Modified `MainActivity.kt` to manage a single message state instead of a list.
- Replaced `ScalingLazyColumn` with a `Box` and `MarkdownTelText` for displaying the single message.
- Removed `ScalingLazyListState` and associated UI elements (`PositionIndicator`, scroll-away behavior for `TimeText`) as they are no longer needed.
- Added `MainActivityUITest.kt` with comprehensive UI tests to verify:
    - Initial prompt display.
    - Your message replacing the previous message.
    - "Thinking..." message replacing your message.
    - My response (success or error) replacing the "Thinking..." message.
    - Network error messages replacing the "Thinking..." message.